### PR TITLE
Passing context to decorated callables

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
     - id: end-of-file-fixer
     - id: trailing-whitespace
 - repo: https://github.com/PyCQA/isort
-  rev: 5.10.1
+  rev: 5.12.0
   hooks:
     - id: isort
       name: isort

--- a/apache_airflow_flowitems/__init__.py
+++ b/apache_airflow_flowitems/__init__.py
@@ -1,4 +1,4 @@
 from .core import FlowItem, PythonItem
 from .decorators import in_tempdir
 
-__version__ = "1.0.1"
+__version__ = "1.0.2"

--- a/apache_airflow_flowitems/core.py
+++ b/apache_airflow_flowitems/core.py
@@ -98,8 +98,8 @@ class PythonItem(FlowItem):
             kwargs[k] = xarg.resolve(context)
 
         # Forward the context dict if the callable takes a "context" parameter
-        spec = inspect.getfullargspec(self.python_callable)
-        if "context" in spec.args or "context" in spec.kwonlyargs:
+        spec = inspect.signature(self.python_callable)
+        if "context" in spec.parameters:
             result = self.python_callable(context=context, **kwargs)
         else:
             result = self.python_callable(**kwargs)

--- a/apache_airflow_flowitems/test_core.py
+++ b/apache_airflow_flowitems/test_core.py
@@ -1,3 +1,4 @@
+import functools
 from datetime import datetime
 from unittest.mock import MagicMock
 
@@ -97,6 +98,25 @@ class TestPythonItem:
         pass
 
     def test_run_autocontext(self):
+        def fun_with_context(context):
+            return context["run_id"]
+
+        pi = core.PythonItem(fun_with_context)
+
+        context = {"run_id": "manual__123"}
+        result = pi._run(**context)
+        assert result == "manual__123"
+        pass
+
+    def test_run_autocontext_of_decorated(self):
+        def dummy_decorator(f):
+            @functools.wraps(f)
+            def wrapper(*args, **kwargs):
+                return f(*args, **kwargs)
+
+            return wrapper
+
+        @dummy_decorator
         def fun_with_context(context):
             return context["run_id"]
 


### PR DESCRIPTION
The fix is not ideal, but still an improvement.

Further reading https://hynek.me/articles/decorators/